### PR TITLE
#000 - WIP: Equate whitespace in ERB and VM

### DIFF
--- a/server/webapp/WEB-INF/rails.new/app/controllers/admin/pipeline_configs_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/admin/pipeline_configs_controller.rb
@@ -16,7 +16,7 @@
 
 module Admin
   class PipelineConfigsController < ::ApplicationController
-    include ApiV1::AuthenticationHelper
+    include ::NotLoadedByDefault::ApiV1::HelperForAuthentication
 
     layout 'pipeline_configs'
     before_action :check_feature_toggle

--- a/server/webapp/WEB-INF/rails.new/app/controllers/api/agents_controller.rb
+++ b/server/webapp/WEB-INF/rails.new/app/controllers/api/agents_controller.rb
@@ -16,7 +16,7 @@
 
 class Api::AgentsController < Api::ApiController
   include AgentBulkEditor
-  include ApiV1::AuthenticationHelper
+  include ::NotLoadedByDefault::ApiV1::HelperForAuthentication
 
   before_action :check_user_and_404
   before_action :check_admin_user_and_401, except: [:index, :show, :job_run_history]

--- a/server/webapp/WEB-INF/rails.new/app/helpers/not_loaded_by_default/base_helper_for_authentication.rb
+++ b/server/webapp/WEB-INF/rails.new/app/helpers/not_loaded_by_default/base_helper_for_authentication.rb
@@ -24,7 +24,7 @@ module NotLoadedByDefault
       end
     end
 
-    def check_user_and_401
+    def verify_user_and_401
       return unless security_service.isSecurityEnabled()
       if current_user.try(:isAnonymous)
         Rails.logger.info("User '#{current_user.getUsername}' attempted to perform an unauthorized action!")

--- a/server/webapp/WEB-INF/rails.new/app/views/pipelines_history/_material_revisions_popup.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/pipelines_history/_material_revisions_popup.html.erb
@@ -1,43 +1,46 @@
+
+
 <div class="build-cause-summary-container">
-  <table>
-    {var materials = new MaterialArray(materialRevisions)}
-    {for material in materials.all}
-    <tbody>
-    <tr>
-      <th colspan="3" class="last highlight-${%material.changed%}">${% material.name() %}</th>
-    </tr>
-    {for modification in material.modifications}
-    {if material.shouldRenderModifications()}
-    <tr>
-      <td class="highlight-${%material.changed%} user">${% modification.user %}</td>
-      <td class="highlight-${%material.changed%} comment">
-        {if material.isPackage()}
-          {if modification.comment != null && modification.comment != ""}
-            {var comment_map = JSON.parse(modification.comment)}
-            {if comment_map.COMMENT != null}
-              ${%comment_map.COMMENT%}<br/>
-            {/if}
-            {if comment_map.TRACKBACK_URL != null}
-              Trackback: <a href="${%comment_map.TRACKBACK_URL%}">${%comment_map.TRACKBACK_URL%}</a>
-            {else}
-            Trackback: Not Provided
-            {/if}
-          {/if}
-        {else}
-          ${% modification.comment.replace(/\n/g,"<br>") %}
-        {/if}
-      </td>
-      <td class="last_highlight-${%material.changed%} revision">${% modification.revision %}</td>
-    </tr>
-    {else}
-    <tr>
-      <td colspan="3" class="last_highlight-${%material.changed%} revision">
-        <a href="<%="#{root_path}${% material.revision_href %}"%>">${% material.revision %}</a>
-      </td>
-    </tr>
+    <table>
+        {var materials = new MaterialArray(materialRevisions)}
+        {for material in materials.all}
+        <tbody>
+        <tr>
+            <th colspan="3" class="last highlight-${%material.changed%}">${% material.name() %}</th>
+        </tr>
+        {for modification in material.modifications}
+        {if material.shouldRenderModifications()}
+        <tr>
+            <td class="highlight-${%material.changed%} user">${% modification.user %}</td>
+            <td class="highlight-${%material.changed%} comment">
+                {if material.isPackage()}
+                
+
+{if modification.comment != null && modification.comment != ""}
+    {var comment_map = JSON.parse(modification.comment)}
+    {if comment_map.COMMENT != null}
+        ${%comment_map.COMMENT%}<br/>
     {/if}
-    {/for}
-    </tbody>
-    {/for}
-  </table>
+    {if comment_map.TRACKBACK_URL != null}
+        Trackback: <a href="${%comment_map.TRACKBACK_URL%}">${%comment_map.TRACKBACK_URL%}</a>
+    {else}
+        Trackback: Not Provided
+    {/if}
+{/if}                {else}
+                    ${% modification.comment.replace(/\n/g,"<br>") %}
+                {/if}
+            </td>
+            <td class="last_highlight-${%material.changed%} revision">${% modification.revision %}</td>
+        </tr>
+        {else}
+        <tr>
+            <td colspan="3" class="last_highlight-${%material.changed%} revision">
+                <a href="<%="#{root_path}${% material.revision_href %}"%>">${% material.revision %}</a>
+            </td>
+        </tr>
+        {/if}
+        {/for}
+        </tbody>
+        {/for}
+    </table>
 </div>

--- a/server/webapp/WEB-INF/rails.new/app/views/pipelines_history/_pipeline_history_list_template.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/pipelines_history/_pipeline_history_list_template.html.erb
@@ -1,30 +1,30 @@
+
+
 <!--To render each pipeline history item-->
 <!--START-->
 {eval}
-pipelineHistoryPage.fixIEZIndexBugs(300);
+    pipelineHistoryPage.fixIEZIndexBugs(300);
 {/eval}
 
 <div id="new-pipeline-history" class="container-in-body">
-  <div class="content_wrapper_outer" id="content_wrapper_outer_pipeline_history">
-    <div class="content_wrapper_inner" id="content_wrapper_inner_pipeline_history">
-      <div class='page_header'>
+<div class="content_wrapper_outer" id="content_wrapper_outer_pipeline_history"><div class="content_wrapper_inner" id="content_wrapper_inner_pipeline_history">
+    <div class='page_header'>
         <div class="entity_title" style="margin-bottom: 0;" id="pipeline_activity_header">
-          <ul class="entity_title">
-            <li class="last">
-              <h1 id="page-title" class="entity_title" style="float: left;"><%= scope[:pipeline_name] %></h1></li>
-          </ul>
+            <ul class="entity_title">
+                <li class="last"><h1 id="page-title" class="entity_title" style="float: left;"><%= scope[:pipeline_name] %></h1></li>
+            </ul>
             <span class="pipeline-buttons" style="float:left;">
                 {if pipelineHistoryPage.isPipelinePaused(data)}
                     {if pipelineHistoryPage.canPause(data)}
                         <a href="javascript:void(0)" id="pause-${%data.pipelineName%}"
                            onclick="pipelineActions.unpausePipeline('${%data.pipelineName%}', this);"
                            class="link_as_button" title="Resume scheduling">
-                          <span>Unpause</span>
+                            <span>Unpause</span>
                         </a>
                     {else}
                         <a href="javascript:void(0)" id="pause-${%data.pipelineName%}"
                            class="link_as_button disabled">
-                          <span>Unpause</span>
+                            <span>Unpause</span>
                         </a>
                     {/if}
                 {else}
@@ -33,174 +33,167 @@ pipelineHistoryPage.fixIEZIndexBugs(300);
                        onclick="pipelineActions.pausePipeline('${%data.pipelineName%}', this);"
                        class="link_as_button"
                        title="Stop scheduling">
-                      <span>Pause</span>
-                    </a>
+                        <span>Pause</span>
+                       </a>
                     {else}
                     <a href="javascript:void(0)" id="pause-${%data.pipelineName%}"
                        onclick="pipelineActions.pausePipeline('${%data.pipelineName%}', this);"
                        class="link_as_button disabled"
                        title="Stop scheduling">
-                      <span>Pause</span>
-                    </a>
+                        <span>Pause</span>
+                       </a>
                     {/if}
                 {/if}
             </span>
         </div>
 
-      </div>
-      {if data.groups}
+    </div>
+{if data.groups}
 
-      {for group in data.groups}
-      <table class="pipeline-history-group" cellpadding="0" cellspacing="0" style="${%pipelineHistoryPage.fixIEZIndexBugs()%}">
+    {for group in data.groups}
+    <table class="pipeline-history-group" cellpadding="0" cellspacing="0" style="${%pipelineHistoryPage.fixIEZIndexBugs()%}">
         <thead>
-        <tr>
-          <th class="" scope="col" style="visibility: hidden;">Pipeline label</th>
-          {for stage in group.config.stages}
-          <th class="column-header{if stage_index == group.config.stages.length - 1} last-stage{/if}" scope="col">
-            <span>${% stage.name %}</span>
-          </th>
-          {/for}
-          <th class="spacer" scope="col">&nbsp;</th>
-        </tr>
+            <tr>
+                <th class="" scope="col" style="visibility: hidden;">Pipeline label</th>
+                {for stage in group.config.stages}
+                <th class="column-header{if stage_index == group.config.stages.length - 1} last-stage{/if}" scope="col">
+                    <span>${% stage.name %}</span>
+                </th>
+                {/for}
+                <th class="spacer" scope="col">&nbsp;</th>
+            </tr>
         </thead>
         <tbody>
-        {if group_index == 0 && data.showForceBuildButton == 'true' }
-        <tr>
-          <th class="pipeline-name" scope="row">
-            <div class="wrapper">
-              {if data.canForce == 'true'}
-              <button class="{if pipelineActions.shouldShowPipelineScheduleButtonAsSpinner(data)}submiting-force-run-pipeline{else}force-run-pipeline{/if}"
-                      title="Trigger this pipeline"
-                      onclick="pipelineActions.schedulePipelineInHistoryPage('${%data.pipelineName%}', this);">Trigger
-              </button>
-              {else}
-              <button class="force-run-pipeline-disabled" title="Cannot trigger this pipeline">Trigger</button>
-              {/if}
-              <span class="pipeline-label" title="revision: ">${% data.nextLabel %}</span><br/>
+            {if group_index == 0 && data.showForceBuildButton == 'true' }
+                <tr>
+                    <th class="pipeline-name" scope="row">
+                        <div class="wrapper">
+                            {if data.canForce == 'true'}
+                            <button class="{if pipelineActions.shouldShowPipelineScheduleButtonAsSpinner(data)}submiting-force-run-pipeline{else}force-run-pipeline{/if}"
+                                    title="Trigger this pipeline"
+                                    onclick="pipelineActions.schedulePipelineInHistoryPage('${%data.pipelineName%}', this);">Trigger</button>
+                            {else}
+                            <button class="force-run-pipeline-disabled" title="Cannot trigger this pipeline">Trigger</button>
+                            {/if}
+                            <span class="pipeline-label" title="revision: ">${% data.nextLabel %}</span><br/>
                             <span class="pipeline-start-time">
                                 <span class="friendly-time"></span>
                             </span>
-            </div>
-          </th>
-          {for stage in group.config.stages}
-          <td>
-            <div class="wrapper">
-              {if stage_index != 0}
-              <button class="disabled-${% pipelineHistoryPage.getApprovalType(group.config, stage_index) %}-gate"></button>
-              {/if}
-              <a class="empty-stage" href="javascript:void(0);"></a></div>
-          </td>
-          {/for}
-          <td class="spacer">&nbsp;</td>
-        </tr>
-        {/if}
-        {for pipeline in group.history}
-        <% vsm_path = vsm_show_path(:pipeline_name => '__pipeline_name__', :pipeline_counter => 779922)
-            .sub('__pipeline_name__', '${% data.pipelineName %}')
-            .sub('779922', '${% pipeline.counterOrLabel %}')
-        %>
-        <tr id="pipeline-${% pipeline.pipelineId %}">
-          <th class="pipeline-name" scope="row" style="${%pipelineHistoryPage.fixIEZIndexBugs()%}">
-            <div class="wrapper" style="${%pipelineHistoryPage.fixIEZIndexBugs()%}">
-              <span id="pipeline-${% pipeline.pipelineId %}-label" class="pipeline-label"> <a href="<%= vsm_path %>" title="${% pipeline.label %}">${%
-                pipeline.label.truncate(17) %}</a></span><br/>
-              <span class="pipeline-info revision" id="pipeline-${% pipeline.pipelineId %}-revision" title="${% pipeline.revision %}">revision: ${% pipeline.revision %}</span><br/>
-              <span id="pipeline-${% pipeline.pipelineId %}-modificationDate" class="pipeline-info">${% pipeline.modification_date %}</span><br/>
+                        </div>
+                    </th>
+                    {for stage in group.config.stages}
+                        <td><div class="wrapper">
+                            {if stage_index != 0}
+                            <button class="disabled-${% pipelineHistoryPage.getApprovalType(group.config, stage_index) %}-gate"></button>
+                            {/if}
+                            <a class="empty-stage" href="javascript:void(0);"></a></div>
+                        </td>
+                    {/for}
+                    <td class="spacer">&nbsp;</td>
+                </tr>
+            {/if}
+            {for pipeline in group.history}
+            <% vsm_path = vsm_show_path(:pipeline_name => '__pipeline_name__', :pipeline_counter => 779922)
+                .sub('__pipeline_name__', '${% data.pipelineName %}')
+                .sub('779922', '${% pipeline.counterOrLabel %}')
+            %>
+            <tr id="pipeline-${% pipeline.pipelineId %}">
+                <th class="pipeline-name" scope="row" style="${%pipelineHistoryPage.fixIEZIndexBugs()%}">
+                    <div class="wrapper" style="${%pipelineHistoryPage.fixIEZIndexBugs()%}">
+                        <span id="pipeline-${% pipeline.pipelineId %}-label" class="pipeline-label"> <a href="<%= vsm_path %>" title="${% pipeline.label %}">${% pipeline.label.truncate(17) %}</a></span><br/>
+                        <span class="pipeline-info revision" id="pipeline-${% pipeline.pipelineId %}-revision" title="${% pipeline.revision %}">revision: ${% pipeline.revision %}</span><br/>
+                        <span id="pipeline-${% pipeline.pipelineId %}-modificationDate" class="pipeline-info">${% pipeline.modification_date %}</span><br/>
                         <span id="pipeline-${% pipeline.pipelineId %}-buildCause"
                               class="pipeline-info popup-${% pipelineHistoryPage.buildCauseActor.getBuildCauseClass(pipeline.pipelineId) %}" style="${%pipelineHistoryPage.fixIEZIndexBugs()%}">
                             {if pipeline.buildCauseBy ==  ''} No modifications
                             {else}
                                 <a href="javascript:void(0)"
-                                   onclick="pipelineHistoryPage.buildCauseActor.hideOrShowBuildCause('${%pipeline.pipelineId%}')">${%
-                                  pipeline.buildCauseBy %}</a>
+                                   onclick="pipelineHistoryPage.buildCauseActor.hideOrShowBuildCause('${%pipeline.pipelineId%}')">${% pipeline.buildCauseBy %}</a>
                             {/if}
                             <div id="pipeline-${%pipeline.pipelineId%}-buildCauseSummary" class="popup ${% pipelineHistoryPage.buildCauseActor.getPositionClass(pipeline.pipelineId) %}" style="${%pipelineHistoryPage.buildCauseActor.getStyleText(pipeline.pipelineId)%};">
-                              <div class="popup-arrow"></div>
-                              <button class="close-popup" onclick="pipelineHistoryPage.buildCauseActor.hideOrShowBuildCause('${%pipeline.pipelineId%}')"></button>
-                              {var materialRevisions = pipeline.materialRevisions}
-                              <%= render :partial => 'material_revisions_popup' %>
-                            </div>
+                                <div class="popup-arrow"></div>
+                                <button class="close-popup" onclick="pipelineHistoryPage.buildCauseActor.hideOrShowBuildCause('${%pipeline.pipelineId%}')"></button>
+                                {var materialRevisions = pipeline.materialRevisions}
+                                <%= render :partial => 'material_revisions_popup' %>                            </div>
                         </span>
-            </div>
-          </th>
-          {for stage in pipeline.stages}
-          <td {if stage_index== pipeline.stages.length - 1} class="last-stage" {
-          /if}>
-          <div class="wrapper">
-            {if stage_index != 0}
-            {if stage.getCanRun == 'true' && stage.scheduled == 'false'}
-            <button class="${% pipelineHistoryPage.getApprovalType(group.config, stage_index) %}-gate" title="Awaiting approval"
-                    id="approve-${% pipeline.counterOrLabel %}-${% stage.stageName %}"
-                    onclick="stageActions.runStage('${% data.pipelineName %}', '${% pipeline.counterOrLabel %}', '${% stage.stageName %}');"></button>
-            {elseif stage.approvedBy == 'changes'}
-            <button class="disabled-${% pipelineHistoryPage.getApprovalType(group.config, stage_index) %}-gate"
-                    title="{if stage.approvedBy}Automatically approved {/if}"></button>
-            {else}
-            <button class="disabled-${% pipelineHistoryPage.getApprovalType(group.config, stage_index) %}-gate"
-                    title="Approved by ${% stage.approvedBy %}"></button>
-            {/if}
-            {/if}
-            {if stage.scheduled == 'true'}
-            <div id="stage-detail-${% pipeline.counterOrLabel %}-${% stage.stageName %}" class="${% pipelineHistoryPage.getState(stage.stageStatus) %}-stage">
-              {if stage.stageStatus == 'Cancelled'}
-              <img alt="" src="<%= asset_path 'stage_bar_cancelled_icon.png' %>">
-              {/if}
-              {if stage.getCanRun == 'true'}
-              <a id="rerun-${% data.pipelineName %}-${% pipeline.counterOrLabel %}-${% stage.stageName %}" class="rerun" title="rerun this stage"
-                 href="javascript:stageActions.runStage('${% data.pipelineName %}', '${% pipeline.counterOrLabel %}', '${% stage.stageName %}');">Re-run</a>
-              {/if}
-              {if stage.getCanCancel == 'true'}
-              <a id="cancel-${% data.pipelineName %}-${% pipeline.counterOrLabel %}-${% stage.stageName %}" class="cancel" title="Cancel this stage"
-                 href="javascript:pipelineActions.cancelPipeline('${% stage.stageId %}', 'cancel-${% data.pipelineName %}-${% pipeline.counterOrLabel %}-${% stage.stageName %}');">Cancel</a>
-              {/if}
-              <a id="stage-detail-${% pipeline.pipelineId %}-${% stage.stageName %}-link" class="detail" title="see the details of this stage"
-                 href="<%= "#{root_path}pipelines/${% stage.stageLocator %}{if 'failed' == stage.stageStatus}#tab-failures{/if}{if 'passed' == stage.stageStatus}#tab-artifacts{/if}".html_safe %>">
-                Details</a>
-            </div>
-            {else}
-            <a class="empty-stage" href="javascript:void(0);"></a>
-            {/if}
-          </div>
-          </td>
-          {/for}
-          {if <%= scope[:pipeline_comment_feature_enabled] %> }
-          <td>
-            <p class="pipeline-info pipeline-history-build-comment">${%pipeline.comment|h%}</p>
+                    </div>
+                </th>
+                {for stage in pipeline.stages}
+                <td {if stage_index == pipeline.stages.length - 1} class="last-stage"{/if}>
+                    <div class="wrapper">
+                        {if stage_index != 0}
+                            {if stage.getCanRun == 'true' && stage.scheduled == 'false'}
+                                 <button class="${% pipelineHistoryPage.getApprovalType(group.config, stage_index) %}-gate" title="Awaiting approval"
+                                         id="approve-${% pipeline.counterOrLabel %}-${% stage.stageName %}"
+                                         onclick="stageActions.runStage('${% data.pipelineName %}', '${% pipeline.counterOrLabel %}', '${% stage.stageName %}');"></button>
+                            {elseif stage.approvedBy == 'changes'}
+                                 <button class="disabled-${% pipelineHistoryPage.getApprovalType(group.config, stage_index) %}-gate"
+                                         title="{if stage.approvedBy}Automatically approved {/if}"></button>
+                            {else}
+                                 <button class="disabled-${% pipelineHistoryPage.getApprovalType(group.config, stage_index) %}-gate"
+                                         title="Approved by ${% stage.approvedBy %}"></button>
+                            {/if}
+                        {/if}
+                        {if stage.scheduled == 'true'}
+                            <div id="stage-detail-${% pipeline.counterOrLabel %}-${% stage.stageName %}" class="${% pipelineHistoryPage.getState(stage.stageStatus) %}-stage">
+                             {if stage.stageStatus == 'Cancelled'}
+                                <img alt="" src="<%= asset_path 'stage_bar_cancelled_icon.png' %>">
+                             {/if}
+                                {if stage.getCanRun == 'true'}
+                                <a id="rerun-${% data.pipelineName %}-${% pipeline.counterOrLabel %}-${% stage.stageName %}" class="rerun" title="rerun this stage"
+                                        href="javascript:stageActions.runStage('${% data.pipelineName %}', '${% pipeline.counterOrLabel %}', '${% stage.stageName %}');">Re-run</a>
+                                {/if}
+                                {if stage.getCanCancel == 'true'}
+                                <a id="cancel-${% data.pipelineName %}-${% pipeline.counterOrLabel %}-${% stage.stageName %}" class="cancel" title="Cancel this stage"
+                                        href="javascript:pipelineActions.cancelPipeline('${% stage.stageId %}', 'cancel-${% data.pipelineName %}-${% pipeline.counterOrLabel %}-${% stage.stageName %}');">Cancel</a>
+                                {/if}
+                                <a id="stage-detail-${% pipeline.pipelineId %}-${% stage.stageName %}-link" class="detail" title="see the details of this stage"
+                                        href="<%= "#{root_path}pipelines/${% stage.stageLocator %}{if 'failed' == stage.stageStatus}#tab-failures{/if}{if 'passed' == stage.stageStatus}#tab-artifacts{/if}".html_safe %>">
+                                        Details</a>
+                            </div>
+                        {else}
+                            <a class="empty-stage" href="javascript:void(0);"></a>
+                        {/if}
+                    </div>
+                    </td>
+                    {/for}
+                    {if <%= scope[:pipeline_comment_feature_enabled] %> }
+                    <td>
+                        <p class="pipeline-info pipeline-history-build-comment">${%pipeline.comment|h%}</p>
 
-            {if pipeline.comment == ""}
-            <input class="pipeline-comment-button" type="button" value="Add Comment"
-                   onClick="PipelineHistoryComment.showModal('${% data.pipelineName %}', '${% pipeline.label %}', '${% pipeline.counterOrLabel %}');">
-            {else}
-            <input class="pipeline-comment-button" type="button" value="Edit Comment"
-                   onClick="PipelineHistoryComment.showModal('${% data.pipelineName %}', '${% pipeline.label %}', '${% pipeline.counterOrLabel %}');">
-            {/if}
+                        {if pipeline.comment == ""}
+                        <input class="pipeline-comment-button" type="button" value="Add Comment"
+                               onClick="PipelineHistoryComment.showModal('${% data.pipelineName %}', '${% pipeline.label %}', '${% pipeline.counterOrLabel %}');">
+                        {else}
+                        <input class="pipeline-comment-button" type="button" value="Edit Comment"
+                               onClick="PipelineHistoryComment.showModal('${% data.pipelineName %}', '${% pipeline.label %}', '${% pipeline.counterOrLabel %}');">
+                        {/if}
 
-            <div class="comment-form" id="comment-form-${% pipeline.counterOrLabel %}" style="display: none;">
-              <div id="comment-box-wrapper">
-                <input type="text" id="comment-input" value="${%pipeline.comment|h|escapeQuotes%}">
-                <button type="button" id="comment-button" class="image submit primary"
-                        onClick="PipelineHistoryComment.submit('${% data.pipelineName %}', '${% pipeline.counterOrLabel %}');">
-                  Submit
-                </button>
-              </div>
-            </div>
-          </td>
-          {/if}
-          <td class="spacer">&nbsp;</td>
-    </div>
-    </tr>
-    {/for}
-    </tbody>
+                        <div class="comment-form" id="comment-form-${% pipeline.counterOrLabel %}" style="display: none;">
+                            <div id="comment-box-wrapper">
+                                <input type="text" id="comment-input" value="${%pipeline.comment|h|escapeQuotes%}">
+                                <button type="button" id="comment-button" class="image submit primary"
+                                   onClick="PipelineHistoryComment.submit('${% data.pipelineName %}', '${% pipeline.counterOrLabel %}');">
+                                    Submit
+                                </button>
+                            </div>
+                        </div>
+                    </td>
+                    {/if}
+                    <td class="spacer">&nbsp;</td>
+                </div>
+            </tr>
+            {/for}
+        </tbody>
     </table>
     {/for}
 
-    {/if}
+  {/if}
 
-    <div class="clear"></div>
-  </div>
-</div>
+  <div class="clear"></div>
+</div></div>
 </div>
 <!--END-->
 {eval}
-pipelineHistoryPage.fixLayout.delay(0.1);
+    pipelineHistoryPage.fixLayout.delay(0.1);
 {/eval}

--- a/server/webapp/WEB-INF/rails.new/app/views/pipelines_history/_pipeline_history_list_template.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/pipelines_history/_pipeline_history_list_template.html.erb
@@ -137,7 +137,7 @@
                         {if stage.scheduled == 'true'}
                             <div id="stage-detail-${% pipeline.counterOrLabel %}-${% stage.stageName %}" class="${% pipelineHistoryPage.getState(stage.stageStatus) %}-stage">
                              {if stage.stageStatus == 'Cancelled'}
-                                <img alt="" src="<%= asset_path 'stage_bar_cancelled_icon.png' %>">
+                                <img alt="" src="<%= asset_path 'g9/stage_bar_cancelled_icon.png' %>">
                              {/if}
                                 {if stage.getCanRun == 'true'}
                                 <a id="rerun-${% data.pipelineName %}-${% pipeline.counterOrLabel %}-${% stage.stageName %}" class="rerun" title="rerun this stage"

--- a/server/webapp/WEB-INF/rails.new/app/views/pipelines_history/index.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/pipelines_history/index.html.erb
@@ -15,37 +15,41 @@
 </style>
 <![endif]-->
 <textarea rows="0" cols="0" id='pipeline-history-list-template' style="display: none;">
-  <%= render :partial => 'pipeline_history_list_template', :locals => {:scope => {:pipeline_name => pipeline_name_escaped,
+<%= render :partial => 'pipeline_history_list_template', :locals => {:scope => {:pipeline_name => pipeline_name_escaped,
                                                                                   :pipeline_comment_feature_enabled => @pipeline_comment_feature_enabled}} -%>
 </textarea>
 <div id="yui-main">
-  <div class="yui-b">
-    <!-- breadcrumbs -->
-    <% $current_page="pipeline_history" %>
-    <!-- /breadcrumbs -->
+    <div class="yui-b">
+        <!-- breadcrumbs -->
+      <% $current_page="pipeline_history" %>
+                <!-- /breadcrumbs -->
 
-    <div id="intro" style="display: none;">
-      <b class="page-intro-arrow"></b>
-      <button id="page-intro-toggle-button" title="Close the description.">Close</button>
-    <p>This view shows you all build activity that has occured in your pipeline over time.
-      Click on a stage in the configuration panel to view activity only within that stage.
-      You can also manually approve stages from this screen to force the next stage to run.
-      <a class="more" target="_blank" title="Learn more from help documentation" href="http://www.go.cd/documentation/user/current/navigation/pipeline_activity_page.html">more...</a>
-    </p>
-    </div>
-    <!-- pipeline start -->
+        
 
-    <div id="pipeline-history">
-      Loading...
-      <img src="<%= image_path 'spinner.gif' %>" alt="loading..."/>
-    </div>
+<div id="intro" style="display: none;">
+<b class="page-intro-arrow"></b>
+<button id="page-intro-toggle-button" title="Close the description.">Close</button>        <p>This view shows you all build activity that has occured in your pipeline over time.
+            Click on a stage in the configuration panel to view activity only within that stage.
+            You can also manually approve stages from this screen to force the next stage to run.
+            <a class="more" target="_blank" title="Learn more from help documentation" href="http://www.go.cd/documentation/user/current/navigation/pipeline_activity_page.html">more...</a>
+        </p>
+        
 
-    <% previous_page = "pipelineHistoryPage.switchToPage('#{pipeline_name_escaped}', paginator.currentPage - 1)" %>
-    <% next_page = "pipelineHistoryPage.switchToPage('#{pipeline_name_escaped}', paginator.currentPage + 1)" %>
-    <% page = "pipelineHistoryPage.switchToPage('#{pipeline_name_escaped}', ${% page.pageNumber %})" %>
-    <textarea id="page-links-template" style="display:none;">
-      {if pagination && paginator.totalPages > 1}
-      {if paginator.hasPrevious()}
+</div>        <!-- pipeline start -->
+
+        <div id="pipeline-history">
+            Loading...
+            <img src="<%= image_path 'spinner.gif' %>" alt="loading..."/>
+        </div>
+
+                
+      <% previous_page = "pipelineHistoryPage.switchToPage('#{pipeline_name_escaped}', paginator.currentPage - 1)" %>
+      <% next_page = "pipelineHistoryPage.switchToPage('#{pipeline_name_escaped}', paginator.currentPage + 1)" %>
+      <% page = "pipelineHistoryPage.switchToPage('#{pipeline_name_escaped}', ${% page.pageNumber %})" %>
+
+<textarea id="page-links-template" style="display:none;">
+{if pagination && paginator.totalPages > 1}
+    {if paginator.hasPrevious()}
         <a href="javascript:void(0)" id="page-previous" class="pagination-previous" onclick="<%= previous_page.html_safe %>">Previous</a>
     {else}
         Previous
@@ -55,8 +59,7 @@
             {if page.pageNumber == paginator.currentPage}
                 <span class="page-num highlight-warning">${% page.pageNumber %}</span>
             {else}
-                <a href="javascript:void(0)" id="page_${% page.pageNumber %}" onclick="<%= page.html_safe %>" class="page-num">${%
-                  page.pageNumber %}</a>
+                <a href="javascript:void(0)" id="page_${% page.pageNumber %}" onclick="<%= page.html_safe %>" class="page-num">${% page.pageNumber %}</a>
             {/if}
         {/if}
         {if page.isSuspension() }
@@ -70,46 +73,47 @@
     {/if}
 {/if}
 </textarea>
-    <div id="page_links" class="pages">
+<div id="page_links" class="pages">
+</div>
+        <!-- pipeline end -->
     </div>
-    <!-- pipeline end -->
-  </div>
 </div>
 </div>
 
 <!-- end bd -->
+
+
 <div id="trans_message" style="position:absolute;display:none">
-  <b class="rtop" style="display:block;background-color: transparent;">
-    <b class="r1"></b>
-    <b class="r2"></b>
-    <b class="r3"></b>
-    <b class="r4"></b>
-  </b>
-  <div class="transparent_message" id="trans_content"></div>
-  <b class="rbottom" style="display:block;background-color: transparent;">
-    <b class="r4"></b>
-    <b class="r3"></b>
-    <b class="r2"></b>
-    <b class="r1"></b>
-  </b>
+    <b class="rtop" style="display:block;background-color: transparent;">
+       <b class="r1"></b>
+       <b class="r2"></b>
+       <b class="r3"></b>
+       <b class="r4"></b>
+    </b>
+    <div class="transparent_message" id="trans_content"></div>
+    <b class="rbottom" style="display:block;background-color: transparent;">
+        <b class="r4"></b>
+        <b class="r3"></b>
+        <b class="r2"></b>
+        <b class="r1"></b>
+    </b>    
 </div>
-
 <script type="text/javascript">
-  var pipelineHistoryPage = new PipelineHistoryPage();
-  var pipelineActions = new PipelineActions();
-  var stageActions = new StageActions();
-  var paginator = new Paginator();
+    var pipelineHistoryPage = new PipelineHistoryPage();
+    var pipelineActions = new PipelineActions();
+    var stageActions = new StageActions();
+    var paginator = new Paginator();
 
-  var dashboard_periodical_executer = new DashboardPeriodicalExecuter('pipelineHistory.json?pipelineName=<%= pipeline_name_escaped %>');
-  var pipelineHistoryObserver = new PipelineHistoryObserver('history');
-  dashboard_periodical_executer.register(pipelineHistoryObserver);
+    var dashboard_periodical_executer = new DashboardPeriodicalExecuter('pipelineHistory.json?pipelineName=<%= pipeline_name_escaped %>');
+    var pipelineHistoryObserver = new PipelineHistoryObserver('history');
+    dashboard_periodical_executer.register(pipelineHistoryObserver);
 
-  dashboard_periodical_executer.start();
+    dashboard_periodical_executer.start();
 
-  //TODO: fix this
-  <% if($pipeline_comment_feature_toggle_key) %>
-    var PipelineHistoryComment = initPipelineHistoryComment(jQuery, Modalbox, dashboard_periodical_executer);
-  <% end %>
-</script>
+    //TODO: fix this
+    <% if($pipeline_comment_feature_toggle_key) %>
+      var PipelineHistoryComment = initPipelineHistoryComment(jQuery, Modalbox, dashboard_periodical_executer);
+    <% end %>
+    </script>
 <!-- END -->
 

--- a/server/webapp/WEB-INF/rails.new/app/views/pipelines_history/index.html.erb
+++ b/server/webapp/WEB-INF/rails.new/app/views/pipelines_history/index.html.erb
@@ -110,8 +110,7 @@
 
     dashboard_periodical_executer.start();
 
-    //TODO: fix this
-    <% if($pipeline_comment_feature_toggle_key) %>
+    <% if(@pipeline_comment_feature_enabled) %>
       var PipelineHistoryComment = initPipelineHistoryComment(jQuery, Modalbox, dashboard_periodical_executer);
     <% end %>
     </script>


### PR DESCRIPTION
- Make whitespace as bad as it was in old VM pages. This helps compare during the move. Using something like:

```
diff <(curl -s http://localhost:8153/go/tab/pipeline/history/admin | sed -ne '/<!-- START -->/,/<!-- END -->/p') <(curl -s http://localhost:8153/go/pipelines/history/admin | sed -ne '/<!-- START -->/,/<!-- END -->/p')
```
